### PR TITLE
feat: implement share-to-calendar core functionality

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,10 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.navigation:navigation-compose:2.8.5")
+    implementation("androidx.datastore:datastore-preferences:1.1.2")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
+    implementation("androidx.compose.material:material-icons-extended")
 
     testImplementation("junit:junit:4.13.2")
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
+    <uses-permission android:name="android.permission.WRITE_CALENDAR" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -15,6 +18,11 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/com/tylermolamphy/sharetocalendar/data/CalendarRepository.kt
+++ b/app/src/main/java/com/tylermolamphy/sharetocalendar/data/CalendarRepository.kt
@@ -1,0 +1,89 @@
+package com.tylermolamphy.sharetocalendar.data
+
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.provider.CalendarContract
+import com.tylermolamphy.sharetocalendar.model.CalendarEvent
+import com.tylermolamphy.sharetocalendar.model.CalendarInfo
+import java.time.ZoneId
+import java.util.TimeZone
+
+class CalendarRepository(private val contentResolver: ContentResolver) {
+
+    fun getCalendars(): List<CalendarInfo> {
+        val calendars = mutableListOf<CalendarInfo>()
+        val projection = arrayOf(
+            CalendarContract.Calendars._ID,
+            CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,
+            CalendarContract.Calendars.ACCOUNT_NAME,
+            CalendarContract.Calendars.CALENDAR_COLOR
+        )
+        val cursor = contentResolver.query(
+            CalendarContract.Calendars.CONTENT_URI,
+            projection,
+            "${CalendarContract.Calendars.VISIBLE} = 1",
+            null,
+            "${CalendarContract.Calendars.CALENDAR_DISPLAY_NAME} ASC"
+        )
+        cursor?.use {
+            while (it.moveToNext()) {
+                calendars.add(
+                    CalendarInfo(
+                        id = it.getLong(0),
+                        displayName = it.getString(1) ?: "",
+                        accountName = it.getString(2) ?: "",
+                        color = it.getInt(3)
+                    )
+                )
+            }
+        }
+        return calendars
+    }
+
+    fun insertEvent(calendarId: Long, event: CalendarEvent): Long? {
+        val timeZone = TimeZone.getDefault().id
+        val zoneId = ZoneId.systemDefault()
+
+        val values = ContentValues().apply {
+            put(CalendarContract.Events.CALENDAR_ID, calendarId)
+            put(CalendarContract.Events.TITLE, event.title)
+            put(CalendarContract.Events.EVENT_TIMEZONE, timeZone)
+
+            if (event.isAllDay) {
+                put(CalendarContract.Events.ALL_DAY, 1)
+                val startMillis = event.startDate
+                    .atStartOfDay(ZoneId.of("UTC"))
+                    .toInstant()
+                    .toEpochMilli()
+                put(CalendarContract.Events.DTSTART, startMillis)
+                put(CalendarContract.Events.DTEND, startMillis + 24 * 60 * 60 * 1000)
+                put(CalendarContract.Events.EVENT_TIMEZONE, "UTC")
+            } else {
+                val startDateTime = event.startDate
+                    .atTime(event.startTime!!)
+                    .atZone(zoneId)
+                    .toInstant()
+                    .toEpochMilli()
+                put(CalendarContract.Events.DTSTART, startDateTime)
+
+                val endTime = event.endTime ?: event.startTime.plusHours(1)
+                val endDateTime = event.startDate
+                    .atTime(endTime)
+                    .atZone(zoneId)
+                    .toInstant()
+                    .toEpochMilli()
+                put(CalendarContract.Events.DTEND, endDateTime)
+            }
+
+            if (event.location.isNotBlank()) {
+                put(CalendarContract.Events.EVENT_LOCATION, event.location)
+            }
+            if (event.description.isNotBlank()) {
+                put(CalendarContract.Events.DESCRIPTION, event.description)
+            }
+        }
+
+        val uri = contentResolver.insert(CalendarContract.Events.CONTENT_URI, values)
+        return uri?.lastPathSegment?.toLongOrNull()
+    }
+}

--- a/app/src/main/java/com/tylermolamphy/sharetocalendar/data/PreferencesRepository.kt
+++ b/app/src/main/java/com/tylermolamphy/sharetocalendar/data/PreferencesRepository.kt
@@ -1,0 +1,29 @@
+package com.tylermolamphy.sharetocalendar.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+
+class PreferencesRepository(private val context: Context) {
+
+    companion object {
+        private val SELECTED_CALENDAR_ID = longPreferencesKey("selected_calendar_id")
+    }
+
+    val selectedCalendarId: Flow<Long?> = context.dataStore.data.map { prefs ->
+        prefs[SELECTED_CALENDAR_ID]
+    }
+
+    suspend fun setSelectedCalendarId(id: Long) {
+        context.dataStore.edit { prefs ->
+            prefs[SELECTED_CALENDAR_ID] = id
+        }
+    }
+}

--- a/app/src/main/java/com/tylermolamphy/sharetocalendar/model/CalendarEvent.kt
+++ b/app/src/main/java/com/tylermolamphy/sharetocalendar/model/CalendarEvent.kt
@@ -1,0 +1,14 @@
+package com.tylermolamphy.sharetocalendar.model
+
+import java.time.LocalDate
+import java.time.LocalTime
+
+data class CalendarEvent(
+    val title: String = "",
+    val startDate: LocalDate = LocalDate.now(),
+    val startTime: LocalTime? = null,
+    val endTime: LocalTime? = null,
+    val location: String = "",
+    val description: String = "",
+    val isAllDay: Boolean = false
+)

--- a/app/src/main/java/com/tylermolamphy/sharetocalendar/model/CalendarInfo.kt
+++ b/app/src/main/java/com/tylermolamphy/sharetocalendar/model/CalendarInfo.kt
@@ -1,0 +1,8 @@
+package com.tylermolamphy.sharetocalendar.model
+
+data class CalendarInfo(
+    val id: Long,
+    val displayName: String,
+    val accountName: String,
+    val color: Int
+)

--- a/app/src/main/java/com/tylermolamphy/sharetocalendar/parser/NaturalLanguageParser.kt
+++ b/app/src/main/java/com/tylermolamphy/sharetocalendar/parser/NaturalLanguageParser.kt
@@ -1,0 +1,326 @@
+package com.tylermolamphy.sharetocalendar.parser
+
+import com.tylermolamphy.sharetocalendar.model.CalendarEvent
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.format.TextStyle
+import java.time.temporal.TemporalAdjusters
+import java.util.Locale
+
+/**
+ * Stateless regex-based parser that converts natural language text into a [CalendarEvent].
+ *
+ * Parsing order: dates -> times -> duration/end time -> location -> title (remainder).
+ */
+object NaturalLanguageParser {
+
+    fun parse(input: String, referenceDate: LocalDate = LocalDate.now()): CalendarEvent {
+        var text = input.trim()
+        var date: LocalDate? = null
+        var startTime: LocalTime? = null
+        var endTime: LocalTime? = null
+        var location = ""
+
+        // --- 1. Parse dates ---
+        val dateResult = extractDate(text, referenceDate)
+        if (dateResult != null) {
+            date = dateResult.first
+            text = dateResult.second
+        }
+
+        // --- 2. Parse times ---
+        val timeResult = extractStartTime(text)
+        if (timeResult != null) {
+            startTime = timeResult.first
+            text = timeResult.second
+        }
+
+        // --- 3. Parse duration / end time ---
+        val endTimeResult = extractEndTime(text, startTime)
+        if (endTimeResult != null) {
+            endTime = endTimeResult.first
+            text = endTimeResult.second
+        }
+
+        // --- 4. Parse location ---
+        val locationResult = extractLocation(text)
+        if (locationResult != null) {
+            location = locationResult.first
+            text = locationResult.second
+        }
+
+        // --- 5. Title = everything remaining ---
+        val title = cleanTitle(text)
+
+        val isAllDay = startTime == null
+        val finalDate = date ?: referenceDate
+
+        // Default 1-hour duration if start time present but no end time
+        val finalEndTime = when {
+            startTime != null && endTime == null -> startTime.plusHours(1)
+            else -> endTime
+        }
+
+        return CalendarEvent(
+            title = title,
+            startDate = finalDate,
+            startTime = startTime,
+            endTime = finalEndTime,
+            location = location,
+            isAllDay = isAllDay
+        )
+    }
+
+    // ---- Date extraction ----
+
+    private val MONTH_NAMES = mapOf(
+        "january" to 1, "jan" to 1,
+        "february" to 2, "feb" to 2,
+        "march" to 3, "mar" to 3,
+        "april" to 4, "apr" to 4,
+        "may" to 5,
+        "june" to 6, "jun" to 6,
+        "july" to 7, "jul" to 7,
+        "august" to 8, "aug" to 8,
+        "september" to 9, "sep" to 9, "sept" to 9,
+        "october" to 10, "oct" to 10,
+        "november" to 11, "nov" to 11,
+        "december" to 12, "dec" to 12
+    )
+
+    private val DAY_NAMES = mapOf(
+        "monday" to DayOfWeek.MONDAY,
+        "tuesday" to DayOfWeek.TUESDAY,
+        "wednesday" to DayOfWeek.WEDNESDAY,
+        "thursday" to DayOfWeek.THURSDAY,
+        "friday" to DayOfWeek.FRIDAY,
+        "saturday" to DayOfWeek.SATURDAY,
+        "sunday" to DayOfWeek.SUNDAY
+    )
+
+    private fun extractDate(text: String, ref: LocalDate): Pair<LocalDate, String>? {
+        val lower = text.lowercase()
+
+        // "today"
+        val todayMatch = Regex("\\btoday\\b", RegexOption.IGNORE_CASE).find(text)
+        if (todayMatch != null) {
+            return ref to text.removeRange(todayMatch.range).trim()
+        }
+
+        // "tomorrow"
+        val tomorrowMatch = Regex("\\btomorrow\\b", RegexOption.IGNORE_CASE).find(text)
+        if (tomorrowMatch != null) {
+            return ref.plusDays(1) to text.removeRange(tomorrowMatch.range).trim()
+        }
+
+        // "in N days/weeks"
+        val relativePattern = Regex("\\bin\\s+(\\d+)\\s+(day|days|week|weeks)\\b", RegexOption.IGNORE_CASE)
+        val relativeMatch = relativePattern.find(text)
+        if (relativeMatch != null) {
+            val n = relativeMatch.groupValues[1].toLong()
+            val unit = relativeMatch.groupValues[2].lowercase()
+            val date = if (unit.startsWith("week")) ref.plusWeeks(n) else ref.plusDays(n)
+            return date to text.removeRange(relativeMatch.range).trim()
+        }
+
+        // "next Monday", "next Tuesday", etc.
+        val nextDayPattern = Regex("\\bnext\\s+(${DAY_NAMES.keys.joinToString("|")})\\b", RegexOption.IGNORE_CASE)
+        val nextDayMatch = nextDayPattern.find(text)
+        if (nextDayMatch != null) {
+            val dayOfWeek = DAY_NAMES[nextDayMatch.groupValues[1].lowercase()]!!
+            val date = ref.with(TemporalAdjusters.next(dayOfWeek))
+            return date to text.removeRange(nextDayMatch.range).trim()
+        }
+
+        // Day name without "next" — means the upcoming occurrence
+        val dayPattern = Regex("\\bon\\s+(${DAY_NAMES.keys.joinToString("|")})\\b", RegexOption.IGNORE_CASE)
+        val dayMatch = dayPattern.find(text)
+        if (dayMatch != null) {
+            val dayOfWeek = DAY_NAMES[dayMatch.groupValues[1].lowercase()]!!
+            val date = ref.with(TemporalAdjusters.nextOrSame(dayOfWeek))
+            return date to text.removeRange(dayMatch.range).trim()
+        }
+
+        // "Month Day" or "Month Day, Year" — e.g. "Jan 15", "January 15, 2025"
+        val monthNames = MONTH_NAMES.keys.joinToString("|")
+        val monthDayPattern = Regex(
+            "\\b($monthNames)\\.?\\s+(\\d{1,2})(?:(?:st|nd|rd|th))?(?:[,\\s]+(\\d{4}))?\\b",
+            RegexOption.IGNORE_CASE
+        )
+        val monthDayMatch = monthDayPattern.find(text)
+        if (monthDayMatch != null) {
+            val month = MONTH_NAMES[monthDayMatch.groupValues[1].lowercase()]!!
+            val day = monthDayMatch.groupValues[2].toInt()
+            val year = if (monthDayMatch.groupValues[3].isNotEmpty()) {
+                monthDayMatch.groupValues[3].toInt()
+            } else {
+                // Use current year, but if the date already passed, use next year
+                val candidate = LocalDate.of(ref.year, month, day)
+                if (candidate.isBefore(ref)) ref.year + 1 else ref.year
+            }
+            return LocalDate.of(year, month, day) to text.removeRange(monthDayMatch.range).trim()
+        }
+
+        // "M/D/YYYY" or "M-D-YYYY"
+        val numericDatePattern = Regex("\\b(\\d{1,2})[/\\-](\\d{1,2})[/\\-](\\d{4})\\b")
+        val numericDateMatch = numericDatePattern.find(text)
+        if (numericDateMatch != null) {
+            val month = numericDateMatch.groupValues[1].toInt()
+            val day = numericDateMatch.groupValues[2].toInt()
+            val year = numericDateMatch.groupValues[3].toInt()
+            return LocalDate.of(year, month, day) to text.removeRange(numericDateMatch.range).trim()
+        }
+
+        return null
+    }
+
+    // ---- Time extraction ----
+
+    private fun extractStartTime(text: String): Pair<LocalTime, String>? {
+        // "noon"
+        val noonMatch = Regex("\\b(?:at\\s+)?noon\\b", RegexOption.IGNORE_CASE).find(text)
+        if (noonMatch != null) {
+            return LocalTime.of(12, 0) to text.removeRange(noonMatch.range).trim()
+        }
+
+        // "midnight"
+        val midnightMatch = Regex("\\b(?:at\\s+)?midnight\\b", RegexOption.IGNORE_CASE).find(text)
+        if (midnightMatch != null) {
+            return LocalTime.of(0, 0) to text.removeRange(midnightMatch.range).trim()
+        }
+
+        // "at 2pm", "at 2:30pm", "at 14:00", "at 2:30 PM"
+        val timePattern = Regex(
+            "\\bat\\s+(\\d{1,2})(?::(\\d{2}))?\\s*([aApP][mM])?\\b"
+        )
+        val timeMatch = timePattern.find(text)
+        if (timeMatch != null) {
+            val time = parseTimeComponents(
+                timeMatch.groupValues[1],
+                timeMatch.groupValues[2],
+                timeMatch.groupValues[3]
+            )
+            if (time != null) {
+                return time to text.removeRange(timeMatch.range).trim()
+            }
+        }
+
+        // Standalone time without "at": "2pm", "3:30PM" — but only if at a word boundary
+        val standaloneTimePattern = Regex(
+            "\\b(\\d{1,2})(?::(\\d{2}))?\\s*([aApP][mM])\\b"
+        )
+        val standaloneMatch = standaloneTimePattern.find(text)
+        if (standaloneMatch != null) {
+            val time = parseTimeComponents(
+                standaloneMatch.groupValues[1],
+                standaloneMatch.groupValues[2],
+                standaloneMatch.groupValues[3]
+            )
+            if (time != null) {
+                return time to text.removeRange(standaloneMatch.range).trim()
+            }
+        }
+
+        return null
+    }
+
+    private fun parseTimeComponents(hourStr: String, minuteStr: String, ampmStr: String): LocalTime? {
+        var hour = hourStr.toIntOrNull() ?: return null
+        val minute = if (minuteStr.isNotEmpty()) minuteStr.toIntOrNull() ?: 0 else 0
+
+        if (ampmStr.isNotEmpty()) {
+            val isPm = ampmStr.lowercase() == "pm"
+            if (isPm && hour != 12) hour += 12
+            if (!isPm && hour == 12) hour = 0
+        }
+
+        if (hour > 23 || minute > 59) return null
+        return LocalTime.of(hour, minute)
+    }
+
+    // ---- End time / Duration ----
+
+    private fun extractEndTime(text: String, startTime: LocalTime?): Pair<LocalTime, String>? {
+        // "for N hour(s)" / "for N minute(s)" / "for N hour(s) and N minute(s)"
+        val durationPattern = Regex(
+            "\\bfor\\s+(\\d+)\\s*(?:hour|hours|hr|hrs)(?:\\s*(?:and\\s*)?(\\d+)\\s*(?:minute|minutes|min|mins))?\\b",
+            RegexOption.IGNORE_CASE
+        )
+        val durationMatch = durationPattern.find(text)
+        if (durationMatch != null && startTime != null) {
+            val hours = durationMatch.groupValues[1].toLong()
+            val minutes = if (durationMatch.groupValues[2].isNotEmpty()) {
+                durationMatch.groupValues[2].toLong()
+            } else 0L
+            val end = startTime.plusHours(hours).plusMinutes(minutes)
+            return end to text.removeRange(durationMatch.range).trim()
+        }
+
+        // "for N minutes" (minutes only)
+        val minutesDurationPattern = Regex(
+            "\\bfor\\s+(\\d+)\\s*(?:minute|minutes|min|mins)\\b",
+            RegexOption.IGNORE_CASE
+        )
+        val minutesDurationMatch = minutesDurationPattern.find(text)
+        if (minutesDurationMatch != null && startTime != null) {
+            val minutes = minutesDurationMatch.groupValues[1].toLong()
+            val end = startTime.plusMinutes(minutes)
+            return end to text.removeRange(minutesDurationMatch.range).trim()
+        }
+
+        // "until 4pm" / "until 16:00"
+        val untilPattern = Regex(
+            "\\buntil\\s+(\\d{1,2})(?::(\\d{2}))?\\s*([aApP][mM])?\\b",
+            RegexOption.IGNORE_CASE
+        )
+        val untilMatch = untilPattern.find(text)
+        if (untilMatch != null) {
+            val time = parseTimeComponents(
+                untilMatch.groupValues[1],
+                untilMatch.groupValues[2],
+                untilMatch.groupValues[3]
+            )
+            if (time != null) {
+                return time to text.removeRange(untilMatch.range).trim()
+            }
+        }
+
+        return null
+    }
+
+    // ---- Location extraction ----
+
+    /**
+     * Extracts location from "at <Place>" or "in <Place>" patterns.
+     * Distinguishes from time "at" by checking if followed by a digit (time token).
+     */
+    private fun extractLocation(text: String): Pair<String, String>? {
+        // "at <Place>" — only if NOT followed by a digit (which would be a time)
+        // Location is assumed to be the rest of the phrase until end-of-string or a known delimiter
+        val atLocationPattern = Regex(
+            "\\b(?:at|in)\\s+([A-Z][A-Za-z0-9' ]+?)(?:\\s*$)",
+            RegexOption.MULTILINE
+        )
+        val atMatch = atLocationPattern.find(text)
+        if (atMatch != null) {
+            val loc = atMatch.groupValues[1].trim()
+            // Don't treat very short matches or time-like strings as locations
+            if (loc.length >= 2 && !loc.matches(Regex("\\d+.*"))) {
+                return loc to text.removeRange(atMatch.range).trim()
+            }
+        }
+
+        return null
+    }
+
+    // ---- Title cleanup ----
+
+    private fun cleanTitle(text: String): String {
+        return text
+            .replace(Regex("\\s{2,}"), " ")  // collapse whitespace
+            .replace(Regex("^[\\s,;\\-]+"), "")  // trim leading punctuation
+            .replace(Regex("[\\s,;\\-]+$"), "")  // trim trailing punctuation
+            .trim()
+    }
+}

--- a/app/src/main/java/com/tylermolamphy/sharetocalendar/ui/EventConfirmationScreen.kt
+++ b/app/src/main/java/com/tylermolamphy/sharetocalendar/ui/EventConfirmationScreen.kt
@@ -1,0 +1,272 @@
+package com.tylermolamphy.sharetocalendar.ui
+
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.tylermolamphy.sharetocalendar.viewmodel.EventConfirmationViewModel
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EventConfirmationScreen(
+    sharedText: String,
+    onDismiss: () -> Unit,
+    viewModel: EventConfirmationViewModel = viewModel()
+) {
+    val event by viewModel.event.collectAsState()
+    val saveResult by viewModel.saveResult.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(sharedText) {
+        if (sharedText.isNotBlank()) {
+            viewModel.parseSharedText(sharedText)
+        }
+    }
+
+    LaunchedEffect(saveResult) {
+        when (saveResult) {
+            is EventConfirmationViewModel.SaveResult.Success -> {
+                Toast.makeText(context, "Event saved!", Toast.LENGTH_SHORT).show()
+                viewModel.resetSaveResult()
+                onDismiss()
+            }
+            is EventConfirmationViewModel.SaveResult.Error -> {
+                Toast.makeText(
+                    context,
+                    (saveResult as EventConfirmationViewModel.SaveResult.Error).message,
+                    Toast.LENGTH_LONG
+                ).show()
+                viewModel.resetSaveResult()
+            }
+            EventConfirmationViewModel.SaveResult.Idle -> {}
+        }
+    }
+
+    val dateFormatter = DateTimeFormatter.ofPattern("EEE, MMM d, yyyy")
+    val timeFormatter = DateTimeFormatter.ofPattern("h:mm a")
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Confirm Event") },
+                navigationIcon = {
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.Default.Close, contentDescription = "Cancel")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // Title
+            OutlinedTextField(
+                value = event.title,
+                onValueChange = { viewModel.updateEvent(event.copy(title = it)) },
+                label = { Text("Title") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+
+            // All-day toggle
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("All-day event", style = MaterialTheme.typography.bodyLarge)
+                Switch(
+                    checked = event.isAllDay,
+                    onCheckedChange = {
+                        viewModel.updateEvent(
+                            event.copy(
+                                isAllDay = it,
+                                startTime = if (it) null else event.startTime ?: LocalTime.of(9, 0),
+                                endTime = if (it) null else event.endTime ?: LocalTime.of(10, 0)
+                            )
+                        )
+                    }
+                )
+            }
+
+            // Date
+            OutlinedTextField(
+                value = event.startDate.format(dateFormatter),
+                onValueChange = {},
+                label = { Text("Date") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        DatePickerDialog(
+                            context,
+                            { _, year, month, day ->
+                                viewModel.updateEvent(
+                                    event.copy(startDate = LocalDate.of(year, month + 1, day))
+                                )
+                            },
+                            event.startDate.year,
+                            event.startDate.monthValue - 1,
+                            event.startDate.dayOfMonth
+                        ).show()
+                    },
+                readOnly = true,
+                trailingIcon = {
+                    Icon(Icons.Default.DateRange, contentDescription = "Pick date")
+                }
+            )
+
+            // Start / End time (only if not all-day)
+            if (!event.isAllDay) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    OutlinedTextField(
+                        value = event.startTime?.format(timeFormatter) ?: "",
+                        onValueChange = {},
+                        label = { Text("Start") },
+                        modifier = Modifier
+                            .weight(1f)
+                            .clickable {
+                                val st = event.startTime ?: LocalTime.of(9, 0)
+                                TimePickerDialog(
+                                    context,
+                                    { _, hour, minute ->
+                                        viewModel.updateEvent(
+                                            event.copy(startTime = LocalTime.of(hour, minute))
+                                        )
+                                    },
+                                    st.hour,
+                                    st.minute,
+                                    false
+                                ).show()
+                            },
+                        readOnly = true,
+                        trailingIcon = {
+                            Icon(Icons.Default.Schedule, contentDescription = "Pick start time")
+                        }
+                    )
+
+                    OutlinedTextField(
+                        value = event.endTime?.format(timeFormatter) ?: "",
+                        onValueChange = {},
+                        label = { Text("End") },
+                        modifier = Modifier
+                            .weight(1f)
+                            .clickable {
+                                val et = event.endTime ?: event.startTime?.plusHours(1) ?: LocalTime.of(10, 0)
+                                TimePickerDialog(
+                                    context,
+                                    { _, hour, minute ->
+                                        viewModel.updateEvent(
+                                            event.copy(endTime = LocalTime.of(hour, minute))
+                                        )
+                                    },
+                                    et.hour,
+                                    et.minute,
+                                    false
+                                ).show()
+                            },
+                        readOnly = true,
+                        trailingIcon = {
+                            Icon(Icons.Default.Schedule, contentDescription = "Pick end time")
+                        }
+                    )
+                }
+            }
+
+            // Location
+            OutlinedTextField(
+                value = event.location,
+                onValueChange = { viewModel.updateEvent(event.copy(location = it)) },
+                label = { Text("Location") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                trailingIcon = {
+                    Icon(Icons.Default.LocationOn, contentDescription = null)
+                }
+            )
+
+            // Description
+            OutlinedTextField(
+                value = event.description,
+                onValueChange = { viewModel.updateEvent(event.copy(description = it)) },
+                label = { Text("Description") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(120.dp),
+                maxLines = 5
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Buttons
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                OutlinedButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Cancel")
+                }
+                Button(
+                    onClick = { viewModel.saveEvent() },
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Save Event")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tylermolamphy/sharetocalendar/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/tylermolamphy/sharetocalendar/ui/SettingsScreen.kt
@@ -1,0 +1,217 @@
+package com.tylermolamphy.sharetocalendar.ui
+
+import android.Manifest
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.tylermolamphy.sharetocalendar.model.CalendarInfo
+import com.tylermolamphy.sharetocalendar.viewmodel.SettingsViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(
+    viewModel: SettingsViewModel = viewModel()
+) {
+    val calendars by viewModel.calendars.collectAsState()
+    val selectedCalendarId by viewModel.selectedCalendarId.collectAsState()
+    val permissionGranted by viewModel.permissionGranted.collectAsState()
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        val allGranted = permissions.values.all { it }
+        viewModel.onPermissionResult(allGranted)
+    }
+
+    LaunchedEffect(Unit) {
+        permissionLauncher.launch(
+            arrayOf(
+                Manifest.permission.READ_CALENDAR,
+                Manifest.permission.WRITE_CALENDAR
+            )
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Share to Calendar") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+        ) {
+            if (!permissionGranted) {
+                PermissionRequest(
+                    onRequestPermission = {
+                        permissionLauncher.launch(
+                            arrayOf(
+                                Manifest.permission.READ_CALENDAR,
+                                Manifest.permission.WRITE_CALENDAR
+                            )
+                        )
+                    }
+                )
+            } else if (calendars.isEmpty()) {
+                Text(
+                    text = "No calendars found on this device.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(16.dp)
+                )
+            } else {
+                Text(
+                    text = "Select default calendar",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(bottom = 12.dp)
+                )
+
+                if (selectedCalendarId != null) {
+                    val selectedCal = calendars.find { it.id == selectedCalendarId }
+                    if (selectedCal != null) {
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(bottom = 16.dp)
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(16.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Check,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(
+                                    text = "Events will be saved to \"${selectedCal.displayName}\"",
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                            }
+                        }
+                    }
+                }
+
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    items(calendars) { calendar ->
+                        CalendarListItem(
+                            calendar = calendar,
+                            isSelected = calendar.id == selectedCalendarId,
+                            onClick = { viewModel.selectCalendar(calendar.id) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CalendarListItem(
+    calendar: CalendarInfo,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp, horizontal = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        RadioButton(
+            selected = isSelected,
+            onClick = onClick
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Box(
+            modifier = Modifier
+                .size(16.dp)
+                .clip(CircleShape)
+                .background(Color(calendar.color))
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column {
+            Text(
+                text = calendar.displayName,
+                style = MaterialTheme.typography.bodyLarge
+            )
+            Text(
+                text = calendar.accountName,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun PermissionRequest(onRequestPermission: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Calendar permission is required",
+            style = MaterialTheme.typography.headlineSmall
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "This app needs access to your calendars to read available calendars and save events.",
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(horizontal = 32.dp)
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(onClick = onRequestPermission) {
+            Text("Grant Permission")
+        }
+    }
+}

--- a/app/src/main/java/com/tylermolamphy/sharetocalendar/viewmodel/EventConfirmationViewModel.kt
+++ b/app/src/main/java/com/tylermolamphy/sharetocalendar/viewmodel/EventConfirmationViewModel.kt
@@ -1,0 +1,74 @@
+package com.tylermolamphy.sharetocalendar.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.tylermolamphy.sharetocalendar.data.CalendarRepository
+import com.tylermolamphy.sharetocalendar.data.PreferencesRepository
+import com.tylermolamphy.sharetocalendar.model.CalendarEvent
+import com.tylermolamphy.sharetocalendar.parser.NaturalLanguageParser
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class EventConfirmationViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val calendarRepository = CalendarRepository(application.contentResolver)
+    private val preferencesRepository = PreferencesRepository(application)
+
+    private val _event = MutableStateFlow(CalendarEvent())
+    val event: StateFlow<CalendarEvent> = _event.asStateFlow()
+
+    private val _saveResult = MutableStateFlow<SaveResult>(SaveResult.Idle)
+    val saveResult: StateFlow<SaveResult> = _saveResult.asStateFlow()
+
+    val selectedCalendarId: StateFlow<Long?> = preferencesRepository.selectedCalendarId
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    fun parseSharedText(text: String) {
+        _event.value = NaturalLanguageParser.parse(text)
+    }
+
+    fun updateEvent(event: CalendarEvent) {
+        _event.value = event
+    }
+
+    fun saveEvent() {
+        viewModelScope.launch {
+            val calendarId = preferencesRepository.selectedCalendarId.first()
+            if (calendarId == null) {
+                _saveResult.value = SaveResult.Error("No calendar selected. Please select a calendar in Settings.")
+                return@launch
+            }
+            val currentEvent = _event.value
+            if (currentEvent.title.isBlank()) {
+                _saveResult.value = SaveResult.Error("Event title cannot be empty.")
+                return@launch
+            }
+            try {
+                val eventId = calendarRepository.insertEvent(calendarId, currentEvent)
+                if (eventId != null) {
+                    _saveResult.value = SaveResult.Success
+                } else {
+                    _saveResult.value = SaveResult.Error("Failed to save event.")
+                }
+            } catch (e: Exception) {
+                _saveResult.value = SaveResult.Error(e.message ?: "Unknown error occurred.")
+            }
+        }
+    }
+
+    fun resetSaveResult() {
+        _saveResult.value = SaveResult.Idle
+    }
+
+    sealed class SaveResult {
+        data object Idle : SaveResult()
+        data object Success : SaveResult()
+        data class Error(val message: String) : SaveResult()
+    }
+}

--- a/app/src/main/java/com/tylermolamphy/sharetocalendar/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/tylermolamphy/sharetocalendar/viewmodel/SettingsViewModel.kt
@@ -1,0 +1,48 @@
+package com.tylermolamphy.sharetocalendar.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.tylermolamphy.sharetocalendar.data.CalendarRepository
+import com.tylermolamphy.sharetocalendar.data.PreferencesRepository
+import com.tylermolamphy.sharetocalendar.model.CalendarInfo
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class SettingsViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val calendarRepository = CalendarRepository(application.contentResolver)
+    private val preferencesRepository = PreferencesRepository(application)
+
+    private val _calendars = MutableStateFlow<List<CalendarInfo>>(emptyList())
+    val calendars: StateFlow<List<CalendarInfo>> = _calendars.asStateFlow()
+
+    val selectedCalendarId: StateFlow<Long?> = preferencesRepository.selectedCalendarId
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    private val _permissionGranted = MutableStateFlow(false)
+    val permissionGranted: StateFlow<Boolean> = _permissionGranted.asStateFlow()
+
+    fun onPermissionResult(granted: Boolean) {
+        _permissionGranted.value = granted
+        if (granted) {
+            loadCalendars()
+        }
+    }
+
+    fun loadCalendars() {
+        viewModelScope.launch {
+            _calendars.value = calendarRepository.getCalendars()
+        }
+    }
+
+    fun selectCalendar(calendarId: Long) {
+        viewModelScope.launch {
+            preferencesRepository.setSelectedCalendarId(calendarId)
+        }
+    }
+}

--- a/app/src/test/java/com/tylermolamphy/sharetocalendar/NaturalLanguageParserTest.kt
+++ b/app/src/test/java/com/tylermolamphy/sharetocalendar/NaturalLanguageParserTest.kt
@@ -1,0 +1,198 @@
+package com.tylermolamphy.sharetocalendar
+
+import com.tylermolamphy.sharetocalendar.parser.NaturalLanguageParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalTime
+
+class NaturalLanguageParserTest {
+
+    // Fixed reference date for deterministic tests
+    private val refDate = LocalDate.of(2025, 1, 10) // Friday, Jan 10, 2025
+
+    @Test
+    fun `parse lunch with Sarah tomorrow at noon`() {
+        val event = NaturalLanguageParser.parse("Lunch with Sarah tomorrow at noon", refDate)
+        assertEquals("Lunch with Sarah", event.title)
+        assertEquals(refDate.plusDays(1), event.startDate)
+        assertEquals(LocalTime.of(12, 0), event.startTime)
+        assertFalse(event.isAllDay)
+    }
+
+    @Test
+    fun `parse team meeting with all fields`() {
+        val event = NaturalLanguageParser.parse(
+            "Team meeting next Tuesday at 3pm for 1 hour in Conference Room B",
+            refDate
+        )
+        assertEquals("Team meeting", event.title)
+        assertEquals(LocalDate.of(2025, 1, 14), event.startDate) // next Tuesday
+        assertEquals(LocalTime.of(15, 0), event.startTime)
+        assertEquals(LocalTime.of(16, 0), event.endTime)
+        assertEquals("Conference Room B", event.location)
+        assertFalse(event.isAllDay)
+    }
+
+    @Test
+    fun `parse dentist appointment with month date`() {
+        val event = NaturalLanguageParser.parse(
+            "Dentist appointment Jan 15 at 2:30pm",
+            refDate
+        )
+        assertEquals("Dentist appointment", event.title)
+        assertEquals(LocalDate.of(2025, 1, 15), event.startDate)
+        assertEquals(LocalTime.of(14, 30), event.startTime)
+    }
+
+    @Test
+    fun `parse no date defaults to reference date`() {
+        val event = NaturalLanguageParser.parse("Call Mom at 5pm", refDate)
+        assertEquals("Call Mom", event.title)
+        assertEquals(refDate, event.startDate)
+        assertEquals(LocalTime.of(17, 0), event.startTime)
+    }
+
+    @Test
+    fun `parse no time results in all-day event`() {
+        val event = NaturalLanguageParser.parse("Team offsite tomorrow", refDate)
+        assertEquals("Team offsite", event.title)
+        assertEquals(refDate.plusDays(1), event.startDate)
+        assertTrue(event.isAllDay)
+        assertNull(event.startTime)
+    }
+
+    @Test
+    fun `parse today keyword`() {
+        val event = NaturalLanguageParser.parse("Standup today at 9am", refDate)
+        assertEquals("Standup", event.title)
+        assertEquals(refDate, event.startDate)
+        assertEquals(LocalTime.of(9, 0), event.startTime)
+    }
+
+    @Test
+    fun `parse numeric date format`() {
+        val event = NaturalLanguageParser.parse("Birthday party 1/25/2025 at 7pm", refDate)
+        assertEquals("Birthday party", event.title)
+        assertEquals(LocalDate.of(2025, 1, 25), event.startDate)
+        assertEquals(LocalTime.of(19, 0), event.startTime)
+    }
+
+    @Test
+    fun `parse relative days`() {
+        val event = NaturalLanguageParser.parse("Follow up in 3 days at 10am", refDate)
+        assertEquals("Follow up", event.title)
+        assertEquals(refDate.plusDays(3), event.startDate)
+        assertEquals(LocalTime.of(10, 0), event.startTime)
+    }
+
+    @Test
+    fun `parse relative weeks`() {
+        val event = NaturalLanguageParser.parse("Review in 2 weeks at 2pm", refDate)
+        assertEquals("Review", event.title)
+        assertEquals(refDate.plusWeeks(2), event.startDate)
+        assertEquals(LocalTime.of(14, 0), event.startTime)
+    }
+
+    @Test
+    fun `parse duration in minutes`() {
+        val event = NaturalLanguageParser.parse(
+            "Quick sync tomorrow at 3pm for 30 minutes",
+            refDate
+        )
+        assertEquals("Quick sync", event.title)
+        assertEquals(LocalTime.of(15, 0), event.startTime)
+        assertEquals(LocalTime.of(15, 30), event.endTime)
+    }
+
+    @Test
+    fun `parse duration hours and minutes`() {
+        val event = NaturalLanguageParser.parse(
+            "Workshop tomorrow at 1pm for 2 hours and 30 minutes",
+            refDate
+        )
+        assertEquals(LocalTime.of(13, 0), event.startTime)
+        assertEquals(LocalTime.of(15, 30), event.endTime)
+    }
+
+    @Test
+    fun `parse until end time`() {
+        val event = NaturalLanguageParser.parse(
+            "Meeting tomorrow at 2pm until 4pm",
+            refDate
+        )
+        assertEquals(LocalTime.of(14, 0), event.startTime)
+        assertEquals(LocalTime.of(16, 0), event.endTime)
+    }
+
+    @Test
+    fun `parse midnight time`() {
+        val event = NaturalLanguageParser.parse("New Year countdown tomorrow at midnight", refDate)
+        assertEquals(LocalTime.of(0, 0), event.startTime)
+    }
+
+    @Test
+    fun `parse 24-hour time format`() {
+        val event = NaturalLanguageParser.parse("Dinner tomorrow at 18:30", refDate)
+        assertEquals(LocalTime.of(18, 30), event.startTime)
+    }
+
+    @Test
+    fun `default end time is start plus one hour`() {
+        val event = NaturalLanguageParser.parse("Call tomorrow at 3pm", refDate)
+        assertEquals(LocalTime.of(15, 0), event.startTime)
+        assertEquals(LocalTime.of(16, 0), event.endTime)
+    }
+
+    @Test
+    fun `parse next day names`() {
+        // refDate is Friday Jan 10, 2025
+        val event = NaturalLanguageParser.parse("Gym next Monday at 6am", refDate)
+        assertEquals(LocalDate.of(2025, 1, 13), event.startDate) // next Monday
+        assertEquals(LocalTime.of(6, 0), event.startTime)
+    }
+
+    @Test
+    fun `parse full month name`() {
+        val event = NaturalLanguageParser.parse("Conference February 20 at 9am", refDate)
+        assertEquals(LocalDate.of(2025, 2, 20), event.startDate)
+    }
+
+    @Test
+    fun `parse month date with year`() {
+        val event = NaturalLanguageParser.parse("Wedding Jun 15, 2026", refDate)
+        assertEquals("Wedding", event.title)
+        assertEquals(LocalDate.of(2026, 6, 15), event.startDate)
+    }
+
+    @Test
+    fun `empty input returns blank event`() {
+        val event = NaturalLanguageParser.parse("", refDate)
+        assertEquals("", event.title)
+        assertEquals(refDate, event.startDate)
+        assertTrue(event.isAllDay)
+    }
+
+    @Test
+    fun `title only input`() {
+        val event = NaturalLanguageParser.parse("Something important", refDate)
+        assertEquals("Something important", event.title)
+        assertEquals(refDate, event.startDate)
+        assertTrue(event.isAllDay)
+    }
+
+    @Test
+    fun `parse 12pm correctly`() {
+        val event = NaturalLanguageParser.parse("Lunch at 12pm", refDate)
+        assertEquals(LocalTime.of(12, 0), event.startTime)
+    }
+
+    @Test
+    fun `parse 12am correctly`() {
+        val event = NaturalLanguageParser.parse("Late night at 12am", refDate)
+        assertEquals(LocalTime.of(0, 0), event.startTime)
+    }
+}


### PR DESCRIPTION
## Summary
- **NLP Parser**: Regex-based natural language parser that converts text like "Lunch with Sarah tomorrow at noon in Conference Room B" into structured calendar events. Supports dates (today, tomorrow, next Monday, Jan 15, 1/15/2025, relative), times (at 2pm, 14:00, noon, midnight), durations (for 1 hour, for 30 minutes, until 4pm), and location extraction.
- **MVVM Architecture**: Single Activity + Compose Navigation with two routes (settings, confirm). DataStore for persisting selected calendar ID. CalendarContract for reading calendars and inserting events.
- **UI Screens**: Settings screen with calendar picker and permission flow. Event confirmation screen with editable title, date/time pickers, location, description, and all-day toggle. ACTION_SEND intent filter for receiving shared text from other apps.

## Files Added/Modified
| File | Purpose |
|------|---------|
| `model/CalendarEvent.kt` | Event data class (title, date, time, location, etc.) |
| `model/CalendarInfo.kt` | Calendar metadata (id, name, account, color) |
| `parser/NaturalLanguageParser.kt` | Stateless regex-based NLP parser |
| `data/CalendarRepository.kt` | CalendarContract read/write operations |
| `data/PreferencesRepository.kt` | DataStore wrapper for settings |
| `viewmodel/SettingsViewModel.kt` | Calendar list + selection state |
| `viewmodel/EventConfirmationViewModel.kt` | Parsed event state + save logic |
| `ui/SettingsScreen.kt` | Calendar picker with permission flow |
| `ui/EventConfirmationScreen.kt` | Editable event confirmation form |
| `MainActivity.kt` | NavHost routing (ACTION_SEND → confirm, else → settings) |
| `NaturalLanguageParserTest.kt` | 22 unit tests for parser |

## Test plan
- [x] `./gradlew test` — 22 parser unit tests pass (0 failures)
- [x] `./gradlew assembleDebug` — APK builds successfully
- [ ] Manual: Install APK, verify settings screen loads and shows calendars
- [ ] Manual: Share text from another app, verify event confirmation screen appears with parsed fields
- [ ] Manual: Save event, verify it appears in calendar

🤖 Generated with [Claude Code](https://claude.com/claude-code)