### PR TITLE
fix: short NLP title, full text → description, fix date/time pickers

### DIFF
--- a/app/src/main/java/com/tylermolamphy/sharetocalendar/ui/EventConfirmationScreen.kt
+++ b/app/src/main/java/com/tylermolamphy/sharetocalendar/ui/EventConfirmationScreen.kt
@@ -5,6 +5,7 @@ import android.app.TimePickerDialog
 import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -152,30 +153,35 @@ fun EventConfirmationScreen(
             }
 
             // Date
-            OutlinedTextField(
-                value = event.startDate.format(dateFormatter),
-                onValueChange = {},
-                label = { Text("Date") },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable {
-                        DatePickerDialog(
-                            context,
-                            { _, year, month, day ->
-                                viewModel.updateEvent(
-                                    event.copy(startDate = LocalDate.of(year, month + 1, day))
-                                )
-                            },
-                            event.startDate.year,
-                            event.startDate.monthValue - 1,
-                            event.startDate.dayOfMonth
-                        ).show()
-                    },
-                readOnly = true,
-                trailingIcon = {
-                    Icon(Icons.Default.DateRange, contentDescription = "Pick date")
-                }
-            )
+            Box {
+                OutlinedTextField(
+                    value = event.startDate.format(dateFormatter),
+                    onValueChange = {},
+                    label = { Text("Date") },
+                    modifier = Modifier.fillMaxWidth(),
+                    readOnly = true,
+                    trailingIcon = {
+                        Icon(Icons.Default.DateRange, contentDescription = "Pick date")
+                    }
+                )
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .clickable {
+                            DatePickerDialog(
+                                context,
+                                { _, year, month, day ->
+                                    viewModel.updateEvent(
+                                        event.copy(startDate = LocalDate.of(year, month + 1, day))
+                                    )
+                                },
+                                event.startDate.year,
+                                event.startDate.monthValue - 1,
+                                event.startDate.dayOfMonth
+                            ).show()
+                        }
+                )
+            }
 
             // Start / End time (only if not all-day)
             if (!event.isAllDay) {
@@ -183,57 +189,67 @@ fun EventConfirmationScreen(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
-                    OutlinedTextField(
-                        value = event.startTime?.format(timeFormatter) ?: "",
-                        onValueChange = {},
-                        label = { Text("Start") },
-                        modifier = Modifier
-                            .weight(1f)
-                            .clickable {
-                                val st = event.startTime ?: LocalTime.of(9, 0)
-                                TimePickerDialog(
-                                    context,
-                                    { _, hour, minute ->
-                                        viewModel.updateEvent(
-                                            event.copy(startTime = LocalTime.of(hour, minute))
-                                        )
-                                    },
-                                    st.hour,
-                                    st.minute,
-                                    false
-                                ).show()
-                            },
-                        readOnly = true,
-                        trailingIcon = {
-                            Icon(Icons.Default.Schedule, contentDescription = "Pick start time")
-                        }
-                    )
+                    Box(modifier = Modifier.weight(1f)) {
+                        OutlinedTextField(
+                            value = event.startTime?.format(timeFormatter) ?: "",
+                            onValueChange = {},
+                            label = { Text("Start") },
+                            modifier = Modifier.fillMaxWidth(),
+                            readOnly = true,
+                            trailingIcon = {
+                                Icon(Icons.Default.Schedule, contentDescription = "Pick start time")
+                            }
+                        )
+                        Box(
+                            modifier = Modifier
+                                .matchParentSize()
+                                .clickable {
+                                    val st = event.startTime ?: LocalTime.of(9, 0)
+                                    TimePickerDialog(
+                                        context,
+                                        { _, hour, minute ->
+                                            viewModel.updateEvent(
+                                                event.copy(startTime = LocalTime.of(hour, minute))
+                                            )
+                                        },
+                                        st.hour,
+                                        st.minute,
+                                        false
+                                    ).show()
+                                }
+                        )
+                    }
 
-                    OutlinedTextField(
-                        value = event.endTime?.format(timeFormatter) ?: "",
-                        onValueChange = {},
-                        label = { Text("End") },
-                        modifier = Modifier
-                            .weight(1f)
-                            .clickable {
-                                val et = event.endTime ?: event.startTime?.plusHours(1) ?: LocalTime.of(10, 0)
-                                TimePickerDialog(
-                                    context,
-                                    { _, hour, minute ->
-                                        viewModel.updateEvent(
-                                            event.copy(endTime = LocalTime.of(hour, minute))
-                                        )
-                                    },
-                                    et.hour,
-                                    et.minute,
-                                    false
-                                ).show()
-                            },
-                        readOnly = true,
-                        trailingIcon = {
-                            Icon(Icons.Default.Schedule, contentDescription = "Pick end time")
-                        }
-                    )
+                    Box(modifier = Modifier.weight(1f)) {
+                        OutlinedTextField(
+                            value = event.endTime?.format(timeFormatter) ?: "",
+                            onValueChange = {},
+                            label = { Text("End") },
+                            modifier = Modifier.fillMaxWidth(),
+                            readOnly = true,
+                            trailingIcon = {
+                                Icon(Icons.Default.Schedule, contentDescription = "Pick end time")
+                            }
+                        )
+                        Box(
+                            modifier = Modifier
+                                .matchParentSize()
+                                .clickable {
+                                    val et = event.endTime ?: event.startTime?.plusHours(1) ?: LocalTime.of(10, 0)
+                                    TimePickerDialog(
+                                        context,
+                                        { _, hour, minute ->
+                                            viewModel.updateEvent(
+                                                event.copy(endTime = LocalTime.of(hour, minute))
+                                            )
+                                        },
+                                        et.hour,
+                                        et.minute,
+                                        false
+                                    ).show()
+                                }
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/com/tylermolamphy/sharetocalendar/viewmodel/EventConfirmationViewModel.kt
+++ b/app/src/main/java/com/tylermolamphy/sharetocalendar/viewmodel/EventConfirmationViewModel.kt
@@ -30,7 +30,20 @@ class EventConfirmationViewModel(application: Application) : AndroidViewModel(ap
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
     fun parseSharedText(text: String) {
-        _event.value = NaturalLanguageParser.parse(text)
+        val parsed = NaturalLanguageParser.parse(text)
+        _event.value = parsed.copy(
+            title = shortenTitle(parsed.title),
+            description = text
+        )
+    }
+
+    private fun shortenTitle(title: String): String {
+        if (title.length <= 50) return title
+        // Take first sentence (split on . ! ?)
+        val firstSentence = title.split(Regex("[.!?]"), limit = 2).first().trim()
+        if (firstSentence.length <= 50) return firstSentence
+        // Still too long — truncate at word boundary + ellipsis
+        return firstSentence.take(47).substringBeforeLast(' ') + "…"
     }
 
     fun updateEvent(event: CalendarEvent) {


### PR DESCRIPTION
## Summary
- **Short NLP title**: Cap the parser's extracted title to ≤50 chars (first sentence or word-boundary truncation with ellipsis), keeping it concise for calendar display
- **Full text in description**: Always store the full original shared text in the description field so no content is lost
- **Fix date/time picker taps**: Overlay a transparent clickable `Box` on top of `readOnly` `OutlinedTextField` fields, fixing the known Compose issue where the text field consumes touch events before the `.clickable` modifier fires

## Test plan
- [x] `./gradlew assembleDebug` — builds successfully
- [x] `./gradlew testDebugUnitTest` — all tests pass
- [ ] Verify short input (e.g. "Lunch with Sarah tomorrow") produces a clean title and full text in description
- [ ] Verify long shared text gets truncated title (≤50 chars) with full text preserved in description
- [ ] Verify tapping date field opens DatePickerDialog
- [ ] Verify tapping start/end time fields opens TimePickerDialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)