### PR TITLE
Add share/confirm screenshot to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -353,9 +353,7 @@ jobs:
           echo "Settings screenshot captured ($(wc -c < screenshot_settings.png) bytes)"
 
           # Screenshot 2: Share/Confirm screen
-          adb shell am start -W -n "$COMPONENT" \
-            -a android.intent.action.SEND -t "text/plain" \
-            --es android.intent.extra.TEXT "Lunch at 1pm"
+          adb shell "am start -W -n '${COMPONENT}' -a android.intent.action.SEND -t 'text/plain' --es android.intent.extra.TEXT 'Lunch at 1pm'"
           sleep 3
           adb exec-out screencap -p > screenshot_confirm.png
           echo "Confirm screenshot captured ($(wc -c < screenshot_confirm.png) bytes)"


### PR DESCRIPTION
## Summary
- Captures a **second screenshot** (Share Confirmation screen) during emulator tests, in addition to the existing Settings screen screenshot
- Displays both screenshots **side-by-side** in the PR comment for reviewer visibility
- Updates artifact upload, ci-screenshots branch push, and PR comment rendering to handle both files

## Test plan
- [ ] CI captures `screenshot_settings.png` (Settings screen)
- [ ] CI captures `screenshot_confirm.png` (Share/Confirm screen via ACTION_SEND intent)
- [ ] Both screenshots uploaded as artifacts
- [ ] Both pushed to `ci-screenshots` branch
- [ ] PR comment shows both screenshots in a side-by-side table

🤖 Generated with [Claude Code](https://claude.com/claude-code)