### PR TITLE
ci: improve workflow efficiency, fix bugs, reduce duplication

### DIFF
--- a/.github/scripts/parse-test-results.sh
+++ b/.github/scripts/parse-test-results.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# parse-test-results.sh — Parse JUnit XML test results into GitHub Actions outputs.
+#
+# Usage: bash .github/scripts/parse-test-results.sh <glob-pattern> [<glob-pattern> ...]
+#
+# Outputs (via $GITHUB_OUTPUT):
+#   total   — total number of tests
+#   passed  — number of passing tests
+#   failed  — number of failing tests
+#   status  — human-readable status string with emoji
+#   table   — Markdown table of per-test results (multiline heredoc)
+
+set -euo pipefail
+
+TOTAL=0
+FAILED=0
+TABLE_ROWS=""
+
+for pattern in "$@"; do
+  for f in $pattern; do
+    [ -f "$f" ] || continue
+
+    T=$(grep -oP 'tests="\K[0-9]+' "$f" | head -1)
+    F=$(grep -oP 'failures="\K[0-9]+' "$f" | head -1)
+    E=$(grep -oP 'errors="\K[0-9]+' "$f" | head -1)
+    TOTAL=$((TOTAL + ${T:-0}))
+    FAILED=$((FAILED + ${F:-0} + ${E:-0}))
+
+    # Extract suite name from <testsuite> element
+    SUITE=$(grep -oP ' name="\K[^"]+' "$f" | head -1)
+    SHORT_SUITE="${SUITE##*.}"
+
+    # Add suite header row
+    TABLE_ROWS="${TABLE_ROWS}| | **${SHORT_SUITE}** | |\n"
+
+    # Parse each <testcase> element
+    while IFS= read -r line; do
+      TC_NAME=$(echo "$line" | grep -oP ' name="\K[^"]+')
+      TC_TIME=$(echo "$line" | grep -oP ' time="\K[^"]+')
+      # Escape pipes in test names for Markdown
+      TC_NAME="${TC_NAME//|/\\|}"
+
+      # Self-closing /> means pass; otherwise has <failure> child
+      if echo "$line" | grep -q '/>'; then
+        TABLE_ROWS="${TABLE_ROWS}| ✅ | ${TC_NAME} | ${TC_TIME}s |\n"
+      else
+        TABLE_ROWS="${TABLE_ROWS}| ❌ | ${TC_NAME} | ${TC_TIME}s |\n"
+      fi
+    done < <(grep '<testcase ' "$f")
+  done
+done
+
+PASSED=$((TOTAL - FAILED))
+echo "total=${TOTAL}" >> "$GITHUB_OUTPUT"
+echo "passed=${PASSED}" >> "$GITHUB_OUTPUT"
+echo "failed=${FAILED}" >> "$GITHUB_OUTPUT"
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "status=⚠️ No tests found" >> "$GITHUB_OUTPUT"
+elif [ "$FAILED" -gt 0 ]; then
+  echo "status=❌ ${PASSED}/${TOTAL} passed (${FAILED} failed)" >> "$GITHUB_OUTPUT"
+else
+  echo "status=✅ ${PASSED}/${TOTAL} passed" >> "$GITHUB_OUTPUT"
+fi
+
+# Output multiline table
+{
+  echo "table<<ENDOFTABLE"
+  echo "| Status | Test | Duration |"
+  echo "|--------|------|----------|"
+  echo -e "${TABLE_ROWS}"
+  echo "ENDOFTABLE"
+} >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,13 +3,19 @@ name: Build & Release
 on:
   push:
     branches: [ "main", "master" ]
+    paths-ignore: ['*.md', 'LICENSE', '.gitignore', 'docs/**']
   pull_request:
     branches: [ "main", "master" ]
+    paths-ignore: ['*.md', 'LICENSE', '.gitignore', 'docs/**']
 
 permissions:
   actions: read
   contents: write
   pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -28,25 +34,13 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: 'gradle'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Run unit tests
-        run: ./gradlew test
-
-      - name: Build debug APK
-        run: ./gradlew assembleDebug
+      - name: Run unit tests & build debug APK
+        run: ./gradlew test assembleDebug
 
       - name: Get APK size
         id: apk
@@ -56,58 +50,9 @@ jobs:
           echo "size=${APK_SIZE}" >> "$GITHUB_OUTPUT"
 
       - name: Get test results
-        if: always()
+        if: "!cancelled()"
         id: tests
-        run: |
-          TOTAL=0
-          FAILED=0
-          TABLE_ROWS=""
-
-          for f in app/build/test-results/testDebugUnitTest/TEST-*.xml; do
-            [ -f "$f" ] || continue
-
-            T=$(grep -oP 'tests="\K[0-9]+' "$f" | head -1)
-            F=$(grep -oP 'failures="\K[0-9]+' "$f" | head -1)
-            E=$(grep -oP 'errors="\K[0-9]+' "$f" | head -1)
-            TOTAL=$((TOTAL + ${T:-0}))
-            FAILED=$((FAILED + ${F:-0} + ${E:-0}))
-
-            # Extract suite name from <testsuite> element
-            SUITE=$(grep -oP ' name="\K[^"]+' "$f" | head -1)
-            SHORT_SUITE="${SUITE##*.}"
-
-            # Add suite header row
-            TABLE_ROWS="${TABLE_ROWS}| | **${SHORT_SUITE}** | |\n"
-
-            # Parse each <testcase> element
-            while IFS= read -r line; do
-              TC_NAME=$(echo "$line" | grep -oP ' name="\K[^"]+')
-              TC_TIME=$(echo "$line" | grep -oP ' time="\K[^"]+')
-              # Escape pipes in test names for Markdown
-              TC_NAME="${TC_NAME//|/\\|}"
-
-              # Self-closing /> means pass; otherwise has <failure> child
-              if echo "$line" | grep -q '/>'; then
-                TABLE_ROWS="${TABLE_ROWS}| ✅ | ${TC_NAME} | ${TC_TIME}s |\n"
-              else
-                TABLE_ROWS="${TABLE_ROWS}| ❌ | ${TC_NAME} | ${TC_TIME}s |\n"
-              fi
-            done < <(grep '<testcase ' "$f")
-          done
-
-          PASSED=$((TOTAL - FAILED))
-          echo "total=${TOTAL}" >> "$GITHUB_OUTPUT"
-          echo "passed=${PASSED}" >> "$GITHUB_OUTPUT"
-          echo "failed=${FAILED}" >> "$GITHUB_OUTPUT"
-
-          # Output multiline table
-          {
-            echo "table<<ENDOFTABLE"
-            echo "| Status | Test | Duration |"
-            echo "|--------|------|----------|"
-            echo -e "${TABLE_ROWS}"
-            echo "ENDOFTABLE"
-          } >> "$GITHUB_OUTPUT"
+        run: bash .github/scripts/parse-test-results.sh 'app/build/test-results/testDebugUnitTest/TEST-*.xml'
 
       - name: Upload debug APK
         if: success()
@@ -119,7 +64,7 @@ jobs:
           retention-days: 14
 
       - name: Comment on PR (build results)
-        if: always() && github.event_name == 'pull_request'
+        if: "!cancelled() && github.event_name == 'pull_request'"
         uses: actions/github-script@v7
         with:
           script: |
@@ -159,7 +104,7 @@ jobs:
               });
               const buildJob = jobs.find(j => j.name.includes('build'));
               if (buildJob) {
-                const step = buildJob.steps.find(s => s.name.includes('Run unit tests'));
+                const step = buildJob.steps.find(s => s.name.includes('Run unit tests & build'));
                 if (step) {
                   stepUrl = `${buildJob.html_url}#step:${step.number}:1`;
                 }
@@ -256,16 +201,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: 'gradle'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -372,72 +308,17 @@ jobs:
           script: bash /tmp/emulator-test.sh
 
       - name: Get instrumented test results
-        if: always()
+        if: "!cancelled()"
         id: ui-tests
         run: |
-          TOTAL=0
-          FAILED=0
-          TABLE_ROWS=""
-
-          # Parse results from all test runs (run1–run3 saved to /tmp, run4 in gradle output dir).
-          # Bash glob expansion is space-safe (unlike $(find ...)), critical for
-          # paths containing "emulator-5554 - 12".
-          for f in /tmp/test-results-run1/connected/*/TEST-*.xml /tmp/test-results-run2/connected/*/TEST-*.xml /tmp/test-results-run3/connected/*/TEST-*.xml app/build/outputs/androidTest-results/connected/*/TEST-*.xml; do
-            [ -f "$f" ] || continue
-
-            T=$(grep -oP 'tests="\K[0-9]+' "$f" | head -1)
-            F=$(grep -oP 'failures="\K[0-9]+' "$f" | head -1)
-            E=$(grep -oP 'errors="\K[0-9]+' "$f" | head -1)
-            TOTAL=$((TOTAL + ${T:-0}))
-            FAILED=$((FAILED + ${F:-0} + ${E:-0}))
-
-            # Extract suite name from <testsuite> element
-            SUITE=$(grep -oP ' name="\K[^"]+' "$f" | head -1)
-            SHORT_SUITE="${SUITE##*.}"
-
-            # Add suite header row
-            TABLE_ROWS="${TABLE_ROWS}| | **${SHORT_SUITE}** | |\n"
-
-            # Parse each <testcase> element
-            while IFS= read -r line; do
-              TC_NAME=$(echo "$line" | grep -oP ' name="\K[^"]+')
-              TC_TIME=$(echo "$line" | grep -oP ' time="\K[^"]+')
-              # Escape pipes in test names for Markdown
-              TC_NAME="${TC_NAME//|/\\|}"
-
-              # Self-closing /> means pass; otherwise has <failure> child
-              if echo "$line" | grep -q '/>'; then
-                TABLE_ROWS="${TABLE_ROWS}| ✅ | ${TC_NAME} | ${TC_TIME}s |\n"
-              else
-                TABLE_ROWS="${TABLE_ROWS}| ❌ | ${TC_NAME} | ${TC_TIME}s |\n"
-              fi
-            done < <(grep '<testcase ' "$f")
-          done
-
-          PASSED=$((TOTAL - FAILED))
-          echo "total=${TOTAL}" >> "$GITHUB_OUTPUT"
-          echo "passed=${PASSED}" >> "$GITHUB_OUTPUT"
-          echo "failed=${FAILED}" >> "$GITHUB_OUTPUT"
-
-          if [ "$TOTAL" -eq 0 ]; then
-            echo "status=⚠️ No tests found" >> "$GITHUB_OUTPUT"
-          elif [ "$FAILED" -gt 0 ]; then
-            echo "status=❌ ${PASSED}/${TOTAL} passed (${FAILED} failed)" >> "$GITHUB_OUTPUT"
-          else
-            echo "status=✅ ${PASSED}/${TOTAL} passed" >> "$GITHUB_OUTPUT"
-          fi
-
-          # Output multiline table
-          {
-            echo "table<<ENDOFTABLE"
-            echo "| Status | Test | Duration |"
-            echo "|--------|------|----------|"
-            echo -e "${TABLE_ROWS}"
-            echo "ENDOFTABLE"
-          } >> "$GITHUB_OUTPUT"
+          bash .github/scripts/parse-test-results.sh \
+            '/tmp/test-results-run1/connected/*/TEST-*.xml' \
+            '/tmp/test-results-run2/connected/*/TEST-*.xml' \
+            '/tmp/test-results-run3/connected/*/TEST-*.xml' \
+            'app/build/outputs/androidTest-results/connected/*/TEST-*.xml'
 
       - name: Upload screenshots
-        if: always()
+        if: "!cancelled()"
         uses: actions/upload-artifact@v4
         with:
           name: emulator-screenshots
@@ -445,26 +326,35 @@ jobs:
           retention-days: 14
 
       - name: Push screenshots to ci-screenshots branch
-        if: always() && hashFiles('screenshot_settings.png') != ''
+        if: "!cancelled() && hashFiles('screenshot_settings.png') != ''"
         run: |
+          PR_NUM=${{ github.event.pull_request.number }}
+          PR_DIR="pr-${PR_NUM}"
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Create or update orphan branch
-          git checkout --orphan ci-screenshots || git checkout ci-screenshots
-          git rm -rf . 2>/dev/null || true
-          cp ${{ github.workspace }}/screenshot_settings.png screenshot_settings.png 2>/dev/null || true
-          cp ${{ github.workspace }}/screenshot_confirm.png screenshot_confirm.png 2>/dev/null || true
+          # Save screenshots before switching branches
+          cp ${{ github.workspace }}/screenshot_settings.png /tmp/screenshot_settings.png 2>/dev/null || true
+          cp ${{ github.workspace }}/screenshot_confirm.png /tmp/screenshot_confirm.png 2>/dev/null || true
+
+          # Fetch and checkout ci-screenshots if it exists, otherwise create orphan
+          git fetch origin ci-screenshots 2>/dev/null && git checkout ci-screenshots || git checkout --orphan ci-screenshots
+
+          # Create PR-specific directory (preserves other PRs' screenshots)
+          mkdir -p "${PR_DIR}"
+          cp /tmp/screenshot_settings.png "${PR_DIR}/screenshot_settings.png" 2>/dev/null || true
+          cp /tmp/screenshot_confirm.png "${PR_DIR}/screenshot_confirm.png" 2>/dev/null || true
 
           # If at least one screenshot exists, commit and push
-          if [ -f screenshot_settings.png ] || [ -f screenshot_confirm.png ]; then
-            git add screenshot_settings.png screenshot_confirm.png 2>/dev/null || true
-            git commit -m "Update screenshots from PR #${{ github.event.pull_request.number }} ($(date -u +%Y-%m-%dT%H:%M:%SZ))"
+          if [ -f "${PR_DIR}/screenshot_settings.png" ] || [ -f "${PR_DIR}/screenshot_confirm.png" ]; then
+            git add "${PR_DIR}" 2>/dev/null || true
+            git commit -m "Update screenshots for PR #${PR_NUM} ($(date -u +%Y-%m-%dT%H:%M:%SZ))"
             git push origin ci-screenshots --force
           fi
 
       - name: Update PR comment with screenshot & UI test results
-        if: always() && github.event_name == 'pull_request'
+        if: "!cancelled() && github.event_name == 'pull_request'"
         uses: actions/github-script@v7
         with:
           script: |
@@ -474,8 +364,9 @@ jobs:
             const uiFailed = '${{ steps.ui-tests.outputs.failed }}';
             const uiTestTable = `${{ steps.ui-tests.outputs.table }}`;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const settingsUrl = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/ci-screenshots/screenshot_settings.png`;
-            const confirmUrl = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/ci-screenshots/screenshot_confirm.png`;
+            const prNum = context.issue.number;
+            const settingsUrl = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/ci-screenshots/pr-${prNum}/screenshot_settings.png`;
+            const confirmUrl = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/ci-screenshots/pr-${prNum}/screenshot_confirm.png`;
             const timestamp = new Date().getTime();
 
             // Look up the emulator job URL and test step number


### PR DESCRIPTION
## Summary
- **Concurrency control**: Cancels in-progress runs when new commits arrive on the same PR/branch
- **Path filtering**: Skips CI on doc-only changes (`*.md`, `LICENSE`, `.gitignore`, `docs/**`)
- **Fix `always()` → `!cancelled()`**: 6 locations where steps would incorrectly run on cancelled workflows
- **Gradle cache**: Replaced manual `actions/cache@v4` with `setup-java` built-in `cache: 'gradle'` (removes 18 lines)
- **Combined Gradle commands**: Merged `./gradlew test` and `./gradlew assembleDebug` into single invocation (saves startup overhead, prevents APK build when tests fail)
- **Shared test parser**: Extracted ~100 lines of duplicated JUnit XML parsing into `.github/scripts/parse-test-results.sh`
- **Screenshot race condition fix**: Uses PR-specific directories (`pr-{number}/`) on `ci-screenshots` branch instead of overwriting root files

## Test plan
- [ ] Push a doc-only commit to a PR branch → verify no workflow runs
- [ ] Open a PR with code changes → verify build job runs, PR comment appears with test results
- [ ] Push a second commit quickly → verify the first run is cancelled
- [ ] Check Gradle cache hit/miss in Actions logs
- [ ] Verify screenshots appear correctly in PR comment with PR-specific URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)