### PR TITLE
Fix APK update conflict (Obtainium "Conflict [Share to Calendar]")

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,20 @@ jobs:
       - name: Run unit tests & build debug APK
         run: ./gradlew test assembleDebug
 
+      - name: Decode release keystore
+        if: github.event_name == 'push'
+        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > ${{ github.workspace }}/release.jks
+
+      - name: Build signed release APK
+        if: github.event_name == 'push'
+        run: ./gradlew assembleRelease
+        env:
+          KEYSTORE_PATH:     ${{ github.workspace }}/release.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS:         ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD:      ${{ secrets.KEY_PASSWORD }}
+          VERSION_CODE:      ${{ github.run_number }}
+
       - name: Run Android lint
         run: ./gradlew lintDebug
 
@@ -54,7 +68,11 @@ jobs:
       - name: Get APK size
         id: apk
         run: |
-          APK_PATH="app/build/outputs/apk/debug/app-debug.apk"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            APK_PATH="app/build/outputs/apk/release/app-release.apk"
+          else
+            APK_PATH="app/build/outputs/apk/debug/app-debug.apk"
+          fi
           APK_SIZE=$(du -h "$APK_PATH" | cut -f1)
           echo "size=${APK_SIZE}" >> "$GITHUB_OUTPUT"
 
@@ -194,7 +212,7 @@ jobs:
           body: |
             Automated build from commit ${{ github.sha }}
             Branch: ${{ github.ref_name }}
-          files: app/build/outputs/apk/debug/app-debug.apk
+          files: app/build/outputs/apk/release/app-release.apk
           generate_release_notes: true
 
   emulator:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,18 +8,39 @@ android {
     namespace = "com.tylermolamphy.sharetocalendar"
     compileSdk = 35
 
+    val versionCodeProp  = System.getenv("VERSION_CODE")?.toIntOrNull() ?: 1
+    val keystorePath     = System.getenv("KEYSTORE_PATH")
+    val keystorePassword = System.getenv("KEYSTORE_PASSWORD")
+    val keyAliasProp     = System.getenv("KEY_ALIAS")
+    val keyPasswordProp  = System.getenv("KEY_PASSWORD")
+
     defaultConfig {
         applicationId = "net.molamphy.tyler.sharetocal"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
+        versionCode = versionCodeProp
         versionName = "0.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        if (keystorePath != null && keystorePassword != null &&
+            keyAliasProp != null && keyPasswordProp != null) {
+            create("release") {
+                storeFile     = file(keystorePath)
+                storePassword = keystorePassword
+                keyAlias      = keyAliasProp
+                keyPassword   = keyPasswordProp
+            }
+        }
+    }
+
     buildTypes {
         release {
+            // signingConfig is null when env vars are absent (local/PR builds); that's intentional.
+            // CI sets all four env vars and gets a properly signed APK.
+            signingConfig = signingConfigs.findByName("release")
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(


### PR DESCRIPTION
## Problem

Installing a new release APK on top of an existing one always failed with a \"Conflict [Share to Calendar]\" error in Obtainium, requiring a full uninstall (which resets calendar permissions).

**Root cause — two compounding issues:**

1. **Signing key changed on every CI run** (primary): GitHub Actions runners are ephemeral. Each run regenerated `~/.android/debug.keystore` from scratch, so every released APK had a *different* signing key. Android strictly enforces that APK updates must be signed with the same key → instant conflict.

2. **`versionCode` hardcoded at `1`** (secondary): Never incremented across releases, so Android couldn't track update lineage.

## Fix

- **Persistent release keystore**: Generated an RSA-2048 keystore stored as `KEYSTORE_BASE64` GitHub Secret. CI now decodes it and uses it to sign every release — consistent key across all builds.
- **Dynamic `versionCode`**: Now reads `VERSION_CODE` env var (`github.run_number` in CI), so it increments with every build.
- **Release APK in releases**: GitHub Releases now attach `app-release.apk` (signed) instead of `app-debug.apk`.
- **Null-safe locally**: `signingConfigs.findByName("release")` returns null when env vars are absent, so local and PR builds still work without secrets.

## Changes

| File | What changed |
|------|-------------|
| `app/build.gradle.kts` | Added `signingConfigs` block + dynamic `versionCode` from env |
| `.github/workflows/build.yml` | Decode keystore → build signed release APK → upload to GitHub Releases |

## Migration note

You'll need to **uninstall once** when upgrading from the old debug-signed APK to the first properly-signed release — this is unavoidable since the old key is gone. After that, every subsequent update will install cleanly over the top.

## Test plan

- [ ] CI build completes and `app-release.apk` appears in the GitHub Release assets
- [ ] Install release on device, then install the *next* release on top → no conflict
- [ ] Confirm `versionCode` increments: `aapt dump badging app-release.apk | grep versionCode`
- [ ] Obtainium update works without uninstalling

🤖 Generated with [Claude Code](https://claude.com/claude-code)