### PR TITLE
Security hardening: 9 fixes across Android app and CI/CD pipeline

### DIFF
--- a/.github/actions/parse-test-results/action.yml
+++ b/.github/actions/parse-test-results/action.yml
@@ -29,41 +29,45 @@ runs:
     - name: Parse test results
       id: parse
       shell: bash
+      env:
+        RESULTS_GLOB: ${{ inputs.results-glob }}
       run: |
         TOTAL=0
         FAILED=0
         TABLE_ROWS=""
 
-        for f in ${{ inputs.results-glob }}; do
-          [ -f "$f" ] || continue
+        for pattern in $RESULTS_GLOB; do
+          for f in $pattern; do
+            [ -f "$f" ] || continue
 
-          T=$(grep -oP 'tests="\K[0-9]+' "$f" | head -1)
-          F=$(grep -oP 'failures="\K[0-9]+' "$f" | head -1)
-          E=$(grep -oP 'errors="\K[0-9]+' "$f" | head -1)
-          TOTAL=$((TOTAL + ${T:-0}))
-          FAILED=$((FAILED + ${F:-0} + ${E:-0}))
+            T=$(grep -oP 'tests="\K[0-9]+' "$f" | head -1)
+            F=$(grep -oP 'failures="\K[0-9]+' "$f" | head -1)
+            E=$(grep -oP 'errors="\K[0-9]+' "$f" | head -1)
+            TOTAL=$((TOTAL + ${T:-0}))
+            FAILED=$((FAILED + ${F:-0} + ${E:-0}))
 
-          # Extract suite name from <testsuite> element
-          SUITE=$(grep -oP ' name="\K[^"]+' "$f" | head -1)
-          SHORT_SUITE="${SUITE##*.}"
+            # Extract suite name from <testsuite> element
+            SUITE=$(grep -oP ' name="\K[^"]+' "$f" | head -1)
+            SHORT_SUITE="${SUITE##*.}"
 
-          # Add suite header row
-          TABLE_ROWS="${TABLE_ROWS}| | **${SHORT_SUITE}** | |\n"
+            # Add suite header row
+            TABLE_ROWS="${TABLE_ROWS}| | **${SHORT_SUITE}** | |\n"
 
-          # Parse each <testcase> element
-          while IFS= read -r line; do
-            TC_NAME=$(echo "$line" | grep -oP ' name="\K[^"]+')
-            TC_TIME=$(echo "$line" | grep -oP ' time="\K[^"]+')
-            # Escape pipes in test names for Markdown
-            TC_NAME="${TC_NAME//|/\\|}"
+            # Parse each <testcase> element
+            while IFS= read -r line; do
+              TC_NAME=$(echo "$line" | grep -oP ' name="\K[^"]+')
+              TC_TIME=$(echo "$line" | grep -oP ' time="\K[^"]+')
+              # Escape pipes in test names for Markdown
+              TC_NAME="${TC_NAME//|/\\|}"
 
-            # Self-closing /> means pass; otherwise has <failure> child
-            if echo "$line" | grep -q '/>'; then
-              TABLE_ROWS="${TABLE_ROWS}| ✅ | ${TC_NAME} | ${TC_TIME}s |\n"
-            else
-              TABLE_ROWS="${TABLE_ROWS}| ❌ | ${TC_NAME} | ${TC_TIME}s |\n"
-            fi
-          done < <(grep '<testcase ' "$f")
+              # Self-closing /> means pass; otherwise has <failure> child
+              if echo "$line" | grep -q '/>'; then
+                TABLE_ROWS="${TABLE_ROWS}| ✅ | ${TC_NAME} | ${TC_TIME}s |\n"
+              else
+                TABLE_ROWS="${TABLE_ROWS}| ❌ | ${TC_NAME} | ${TC_TIME}s |\n"
+              fi
+            done < <(grep '<testcase ' "$f")
+          done
         done
 
         PASSED=$((TOTAL - FAILED))

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Decode release keystore
         if: github.event_name == 'push'
-        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > ${{ github.workspace }}/release.jks
+        run: umask 077 && echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > ${{ github.workspace }}/release.jks
 
       - name: Build signed release APK
         if: github.event_name == 'push'
@@ -54,6 +54,10 @@ jobs:
           KEY_PASSWORD:      ${{ secrets.KEY_PASSWORD }}
           VERSION_CODE:      ${{ github.run_number }}
 
+      - name: Delete release keystore
+        if: github.event_name == 'push'
+        run: rm -f ${{ github.workspace }}/release.jks
+
       - name: Run Android lint
         run: ./gradlew lintDebug
 
@@ -63,7 +67,7 @@ jobs:
         with:
           name: lint-report
           path: app/build/reports/lint-results-debug.html
-          retention-days: 14
+          retention-days: 7
 
       - name: Get APK size
         id: apk
@@ -90,7 +94,7 @@ jobs:
         with:
           name: debug-apk
           path: app/build/outputs/apk/debug/app-debug.apk
-          retention-days: 14
+          retention-days: 7
 
       - name: Comment on PR (build results)
         if: "!cancelled() && github.event_name == 'pull_request'"
@@ -205,7 +209,7 @@ jobs:
 
       - name: Create GitHub Release
         if: github.event_name == 'push'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: "Build ${{ steps.version.outputs.tag }}"
@@ -335,7 +339,7 @@ jobs:
           chmod +x /tmp/emulator-test.sh
 
       - name: Run emulator tests & capture screenshot
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b # v2
         with:
           api-level: 31
           arch: x86_64
@@ -358,7 +362,7 @@ jobs:
         with:
           name: emulator-screenshots
           path: screenshot_*.png
-          retention-days: 14
+          retention-days: 7
 
       - name: Push screenshots to ci-screenshots branch
         if: "!cancelled() && hashFiles('screenshot_settings.png') != ''"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,7 @@ android {
             // signingConfig is null when env vars are absent (local/PR builds); that's intentional.
             // CI sets all four env vars and gets a properly signed APK.
             signingConfig = signingConfigs.findByName("release")
+            isDebuggable = false
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
     <uses-permission android:name="android.permission.WRITE_CALENDAR" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"

--- a/app/src/main/java/com/tylermolamphy/sharetocalendar/MainActivity.kt
+++ b/app/src/main/java/com/tylermolamphy/sharetocalendar/MainActivity.kt
@@ -52,7 +52,7 @@ class MainActivity : ComponentActivity() {
 
     private fun extractSharedText(intent: Intent?): String? {
         if (intent?.action == Intent.ACTION_SEND && intent.type == "text/plain") {
-            return intent.getStringExtra(Intent.EXTRA_TEXT)
+            return intent.getStringExtra(Intent.EXTRA_TEXT)?.take(10_000)
         }
         return null
     }

--- a/app/src/main/java/com/tylermolamphy/sharetocalendar/viewmodel/EventConfirmationViewModel.kt
+++ b/app/src/main/java/com/tylermolamphy/sharetocalendar/viewmodel/EventConfirmationViewModel.kt
@@ -77,7 +77,8 @@ class EventConfirmationViewModel(application: Application) : AndroidViewModel(ap
                     _saveResult.value = SaveResult.Error("Failed to save event.")
                 }
             } catch (e: Exception) {
-                _saveResult.value = SaveResult.Error(e.message ?: "Unknown error occurred.")
+                android.util.Log.e("EventConfirmationVM", "Failed to save event", e)
+                _saveResult.value = SaveResult.Error("Failed to save event. Please try again.")
             }
         }
     }

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>


### PR DESCRIPTION
## Summary

Security audit follow-up addressing real-world risks across the Android app and GitHub Actions pipeline.

**Android App**
- `AndroidManifest.xml`: `allowBackup=false` (blocks `adb backup` data extraction) + `networkSecurityConfig` reference
- `network_security_config.xml` (**new**): blocks all cleartext HTTP traffic
- `MainActivity.kt`: cap shared text input at 10,000 chars (prevents memory abuse from malicious intents)
- `EventConfirmationViewModel.kt`: log exceptions privately with `Log.e`; show generic message to UI instead of raw exception text
- `build.gradle.kts`: explicit `isDebuggable = false` in release build (defense-in-depth)

**GitHub Actions**
- `build.yml`: pin `softprops/action-gh-release` and `reactivecircus/android-emulator-runner` to commit SHAs (prevents mutable tag supply chain attacks)
- `build.yml`: decode keystore with `umask 077` (restricts file permissions); delete `release.jks` immediately after APK is built
- `build.yml`: reduce artifact retention from 14 → 7 days (debug APKs and lint reports don't need long retention)
- `action.yml`: route `results-glob` input through an env var before shell expansion (fixes template injection risk)

## Test plan
- [ ] CI passes on this PR (unit tests + lint)
- [ ] Release build compiles without errors on merge to main
- [ ] Keystore file deletion step visible in build log after merge
- [ ] No new lint warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)